### PR TITLE
修改PoolEx创建连接池的条件，修复Connection 下配置文件maximum-connection-count项为0的时候抛异常

### DIFF
--- a/src/Network/Connection/PoolEx.php
+++ b/src/Network/Connection/PoolEx.php
@@ -65,10 +65,13 @@ class PoolEx
 
         $min = $poolConf["minimum-connection-count"];
         $max = $poolConf["maximum-connection-count"];
-        $r = $this->poolEx->createConnPool($min, $max);
-        if ($r === false) {
-            throw new ZanException("create conn pool fail [pool=$this->poolType]");
+        if($min >= 0 && $max > 0 && $min < $max){
+            $r = $this->poolEx->createConnPool($min, $max);
+            if ($r === false) {
+                throw new ZanException("create conn pool fail [pool=$this->poolType]");
+            }
         }
+        return;
     }
 
     public function get()


### PR DESCRIPTION
如题：修改PoolEx创建连接池的条件，修复Connection 下配置文件maximum-connection-count项为0的时候抛异常

**问题现象**：运行bin下启动脚本时报：[image](https://user-images.githubusercontent.com/5779513/28161017-81ab21bc-67f4-11e7-8bc8-e43a86471025.png)

**问题触发原因分析**：
我的test环境connection 文件夹下tcp文件配置：

 ```php
<?php

return [
    'trace' => [
              xxxx省略
        ],
        'pool'  => [
            'keeping-sleep-time' => 10000,
            'init-connection'=> 1,
            'maximum-connection-count' => 0, //触发问题项
            'minimum-connection-count' => 0,
        ],
    ],
];
```

如果zan扩展存在swoole_connpool类，将会走扩展创建连接池，这个时候调用的是PoolEx的init方法：
```php
    private function init()
    {
        $poolConf = $this->config["pool"];
        $conf = $this->config;
        $conf["connectTimeout"] = $this->config["connect_timeout"];

        if (isset($poolConf["heartbeat-construct"]) && isset($poolConf["heartbeat-check"])) {
            $conf["hbIntervalTime"] = $poolConf["heartbeat-time"];
            $conf["hbTimeout"] = $poolConf["heartbeat-timeout"];

            $this->poolEx->on("hbConstruct", $poolConf["heartbeat-construct"]);
            $this->poolEx->on("hbCheck", $poolConf["heartbeat-check"]);
        }

        $r = $this->poolEx->setConfig($conf);
        if ($r === false) {
            throw new InvalidArgumentException("invalid connection pool config, [pool=$this->poolType]");
        }
        $min = $poolConf["minimum-connection-count"];
        $max = $poolConf["maximum-connection-count"];
        $r = $this->poolEx->createConnPool($min, $max);
        if ($r === false) {
            throw new ZanException("create conn pool fail [pool=$this->poolType]");
        }
    }
```

可以看到max为0时也会传入createConnPool 因为下方条件而被返回false,上面init方法会触发异常
```c
ZEND_METHOD(swoole_connpool,createConnPool)
{
  ....xxx...

    if (minNum < 0 || maxNum <= 0 || minNum > maxNum)
    {    
        RETURN_FALSE;
    }    
}
```
所以增加了过滤条件